### PR TITLE
refator : 이메일 대신 유저명 반환

### DIFF
--- a/backend/src/main/java/com/bigPicture/backend/payload/response/BookDetailResponse.java
+++ b/backend/src/main/java/com/bigPicture/backend/payload/response/BookDetailResponse.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @NoArgsConstructor
 public class BookDetailResponse {
-    private String email;
+    private String name;
     private Long bookId;
     private String title;
     private String cover;
@@ -23,7 +23,7 @@ public class BookDetailResponse {
 
     public static BookDetailResponse of(Book book) {
         return new BookDetailResponse(
-                book.getUser().getEmail(),
+                book.getUser().getName(),
                 book.getId(),
                 book.getTitle(),
                 book.getCover(),

--- a/backend/src/main/java/com/bigPicture/backend/payload/response/BookInfoResponse.java
+++ b/backend/src/main/java/com/bigPicture/backend/payload/response/BookInfoResponse.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 public class BookInfoResponse {
 
     //목록 보기용임으로 페이지는 응답X
-    private String email;
+    private String name;
     private Long bookId;
     private String title;
     private String cover;
@@ -23,7 +23,7 @@ public class BookInfoResponse {
 
     public static BookInfoResponse of(Book book) {
         return new BookInfoResponse(
-                book.getUser().getEmail(),
+                book.getUser().getName(),
                 book.getId(),
                 book.getTitle(),
                 book.getCover(),

--- a/backend/src/main/java/com/bigPicture/backend/payload/response/UserBookInfoResponse.java
+++ b/backend/src/main/java/com/bigPicture/backend/payload/response/UserBookInfoResponse.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 public class UserBookInfoResponse {
 
     //목록 보기용임으로 페이지는 응답X
-    private String email;
+    private String name;
     private Long bookId;
     private String title;
     private String cover;
@@ -23,7 +23,7 @@ public class UserBookInfoResponse {
 
     public static UserBookInfoResponse of(Book book) {
         return new UserBookInfoResponse(
-                book.getUser().getEmail(),
+                book.getUser().getName(),
                 book.getId(),
                 book.getTitle(),
                 book.getCover(),


### PR DESCRIPTION
책 조회 하면 응답중에 유저이메일을 응답하는 부분이 있는데 
책이라서 저자명이 필요하므로
유저명을 반환하게 바꿈